### PR TITLE
Update open weather endpoint to use /weather endpoint 

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -33,7 +33,7 @@ def get_weather():
         return {"message": "must provide lat and lon parameters"}
 
     response = requests.get(
-        "https://api.openweathermap.org/data/2.5/onecall",
+        "https://api.openweathermap.org/data/2.5/weather",
         params={"lat": lat_query, "lon": lon_query, "appid": weather_key}
     )
     return response.json()


### PR DESCRIPTION
Changing endpoint from /onecall to /weather so students can use the free API key

https://adadevelopersacademy.slack.com/archives/C048ULKSFRV/p1670454018663369